### PR TITLE
实现上传聚类中心至GPU

### DIFF
--- a/cuda/cuda_wrapper.cu
+++ b/cuda/cuda_wrapper.cu
@@ -26,7 +26,49 @@ extern "C" {
     bool cuda_is_available() {
         int device_count;
         cudaError_t err = cudaGetDeviceCount(&device_count);
-        return (err == cudaSuccess && device_count > 0);
+        if (err != cudaSuccess) {
+            printf("DEBUG: cudaGetDeviceCount 失败: %s\n", cudaGetErrorString(err));
+            return false;
+        }
+        if (device_count <= 0) {
+            printf("DEBUG: 没有检测到 CUDA 设备\n");
+            return false;
+        }
+        printf("DEBUG: CUDA 可用，检测到 %d 个设备\n", device_count);
+        return true;
+    }
+    
+    // 简单的 CUDA 功能测试
+    bool cuda_basic_test() {
+        printf("DEBUG: 开始 CUDA 基本功能测试\n");
+        
+        // 测试设备设置
+        cudaError_t err = cudaSetDevice(0);
+        if (err != cudaSuccess) {
+            printf("ERROR: cudaSetDevice 失败: %s\n", cudaGetErrorString(err));
+            return false;
+        }
+        printf("DEBUG: cudaSetDevice 成功\n");
+        
+        // 测试内存分配
+        float *d_test;
+        err = cudaMalloc(&d_test, 1024);
+        if (err != cudaSuccess) {
+            printf("ERROR: cudaMalloc 测试失败: %s\n", cudaGetErrorString(err));
+            return false;
+        }
+        printf("DEBUG: cudaMalloc 测试成功\n");
+        
+        // 测试内存释放
+        err = cudaFree(d_test);
+        if (err != cudaSuccess) {
+            printf("ERROR: cudaFree 测试失败: %s\n", cudaGetErrorString(err));
+            return false;
+        }
+        printf("DEBUG: cudaFree 测试成功\n");
+        
+        printf("DEBUG: CUDA 基本功能测试通过\n");
+        return true;
     }
 
     /**
@@ -116,6 +158,360 @@ extern "C" {
         
         //TODO:
 
+        return 0;
+    }
+
+    // CUDA核函数：计算L2距离
+    __global__ void compute_l2_distances_kernel(const float* centers, 
+                                               const float* query_vector, 
+                                               float* distances, 
+                                               int num_centers, 
+                                               int dimensions) {
+        int idx = blockIdx.x * blockDim.x + threadIdx.x;
+        
+        if (idx < num_centers) {
+            float sum = 0.0f;
+            for (int i = 0; i < dimensions; i++) {
+                float diff = centers[idx * dimensions + i] - query_vector[i];
+                sum += diff * diff;
+            }
+            distances[idx] = sqrtf(sum);
+        }
+    }
+
+    // CUDA核函数：计算余弦距离
+    __global__ void compute_cosine_distances_kernel(const float* centers, 
+                                                   const float* query_vector, 
+                                                   float* distances, 
+                                                   int num_centers, 
+                                                   int dimensions) {
+        int idx = blockIdx.x * blockDim.x + threadIdx.x;
+        
+        if (idx < num_centers) {
+            float dot_product = 0.0f;
+            float norm_query = 0.0f;
+            float norm_center = 0.0f;
+            
+            for (int i = 0; i < dimensions; i++) {
+                float q_val = query_vector[i];
+                float c_val = centers[idx * dimensions + i];
+                
+                dot_product += q_val * c_val;
+                norm_query += q_val * q_val;
+                norm_center += c_val * c_val;
+            }
+            
+            float norm_product = sqrtf(norm_query) * sqrtf(norm_center);
+            if (norm_product > 0.0f) {
+                distances[idx] = 1.0f - (dot_product / norm_product);
+            } else {
+                distances[idx] = 1.0f;
+            }
+        }
+    }
+
+    // 初始化GPU聚类中心搜索上下文
+    CudaCenterSearchContext* cuda_center_search_init(int num_centers, int dimensions, bool use_zero_copy) {
+        printf("DEBUG: 开始初始化 GPU 上下文\n");
+        printf("DEBUG: 参数 - 聚类中心数: %d, 维度: %d, 零拷贝: %s\n", 
+               num_centers, dimensions, use_zero_copy ? "是" : "否");
+        
+        if (!cuda_is_available()) {
+            printf("ERROR: CUDA不可用，无法初始化GPU上下文\n");
+            return NULL;
+        }
+        
+        printf("DEBUG: CUDA 可用性检查通过\n");
+        
+        // 检查 CUDA 设备信息
+        int device_count;
+        cudaError_t device_err = cudaGetDeviceCount(&device_count);
+        if (device_err == cudaSuccess) {
+            printf("DEBUG: 检测到 %d 个 CUDA 设备\n", device_count);
+            
+            cudaDeviceProp prop;
+            cudaError_t prop_err = cudaGetDeviceProperties(&prop, 0);
+            if (prop_err == cudaSuccess) {
+                printf("DEBUG: 设备 0: %s, 计算能力: %d.%d\n", 
+                       prop.name, prop.major, prop.minor);
+                printf("DEBUG: 总内存: %.2f GB, 可用内存: %.2f GB\n", 
+                       prop.totalGlobalMem / (1024.0*1024.0*1024.0),
+                       prop.totalGlobalMem / (1024.0*1024.0*1024.0));
+            } else {
+                printf("WARNING: 无法获取设备属性: %s\n", cudaGetErrorString(prop_err));
+            }
+        } else {
+            printf("WARNING: 无法获取设备数量: %s\n", cudaGetErrorString(device_err));
+        }
+
+        // 检查参数有效性
+        if (num_centers <= 0 || dimensions <= 0) {
+            printf("ERROR: 无效参数 - 聚类中心数: %d, 维度: %d\n", num_centers, dimensions);
+            return NULL;
+        }
+
+        CudaCenterSearchContext* ctx = (CudaCenterSearchContext*)malloc(sizeof(CudaCenterSearchContext));
+        if (!ctx) {
+            printf("ERROR: 无法分配CUDA上下文内存\n");
+            return NULL;
+        }
+
+        memset(ctx, 0, sizeof(CudaCenterSearchContext));
+        ctx->num_centers = num_centers;
+        ctx->dimensions = dimensions;
+        ctx->use_zero_copy = use_zero_copy;
+
+        // 计算内存需求
+        size_t centers_size = num_centers * dimensions * sizeof(float);
+        size_t query_size = dimensions * sizeof(float);
+        size_t distances_size = num_centers * sizeof(float);
+        
+        printf("INFO: 尝试分配GPU内存 - 聚类中心: %zu字节, 查询向量: %zu字节, 距离: %zu字节\n", 
+               centers_size, query_size, distances_size);
+
+        // 检查GPU内存是否足够
+        size_t free_memory, total_memory;
+        cudaError_t mem_err = cudaMemGetInfo(&free_memory, &total_memory);
+        if (mem_err == cudaSuccess) {
+            size_t required_memory = centers_size + query_size + distances_size;
+            if (use_zero_copy) {
+                required_memory += centers_size; // 零拷贝需要额外的页锁定内存
+            }
+            
+            if (free_memory < required_memory) {
+                printf("WARNING: GPU内存不足 - 需要: %zu字节, 可用: %zu字节\n", required_memory, free_memory);
+                // 不直接返回NULL，尝试分配看看是否真的会失败
+            }
+        }
+
+        cudaError_t err;
+        
+        if (use_zero_copy) {
+            // 零拷贝模式：分配页锁定主机内存
+            printf("INFO: 尝试分配页锁定内存 (%zu字节)\n", centers_size);
+            err = cudaHostAlloc(&ctx->h_centers_pinned, centers_size, cudaHostAllocMapped);
+            if (err != cudaSuccess) {
+                printf("ERROR: 页锁定内存分配失败: %s (需要%zu字节)\n", 
+                       cudaGetErrorString(err), centers_size);
+                free(ctx);
+                return NULL;
+            }
+            
+            // 获取GPU可访问的地址
+            err = cudaHostGetDevicePointer(&ctx->d_centers, ctx->h_centers_pinned, 0);
+            if (err != cudaSuccess) {
+                printf("ERROR: 获取GPU设备指针失败: %s\n", cudaGetErrorString(err));
+                cudaFreeHost(ctx->h_centers_pinned);
+                free(ctx);
+                return NULL;
+            }
+            printf("INFO: 页锁定内存分配成功\n");
+        } else {
+            // 标准模式：分配GPU设备内存
+            printf("INFO: 尝试分配GPU设备内存 (%zu字节)\n", centers_size);
+            err = cudaMalloc(&ctx->d_centers, centers_size);
+            if (err != cudaSuccess) {
+                printf("ERROR: GPU设备内存分配失败: %s (需要%zu字节)\n", 
+                       cudaGetErrorString(err), centers_size);
+                free(ctx);
+                return NULL;
+            }
+            printf("INFO: GPU设备内存分配成功\n");
+        }
+
+        // 分配查询向量内存
+        err = cudaMalloc(&ctx->d_query_vector, query_size);
+        if (err != cudaSuccess) {
+            printf("ERROR: 查询向量内存分配失败: %s\n", cudaGetErrorString(err));
+            if (use_zero_copy) {
+                cudaFreeHost(ctx->h_centers_pinned);
+            } else {
+                cudaFree(ctx->d_centers);
+            }
+            free(ctx);
+            return NULL;
+        }
+
+        // 分配距离结果内存
+        err = cudaMalloc(&ctx->d_distances, distances_size);
+        if (err != cudaSuccess) {
+            printf("ERROR: 距离结果内存分配失败: %s\n", cudaGetErrorString(err));
+            if (use_zero_copy) {
+                cudaFreeHost(ctx->h_centers_pinned);
+            } else {
+                cudaFree(ctx->d_centers);
+            }
+            cudaFree(ctx->d_query_vector);
+            free(ctx);
+            return NULL;
+        }
+
+        ctx->initialized = true;
+        printf("INFO: GPU上下文初始化成功\n");
+        return ctx;
+    }
+
+    // 清理GPU聚类中心搜索上下文
+    void cuda_center_search_cleanup(CudaCenterSearchContext* ctx) {
+        if (!ctx) {
+            printf("WARNING: 尝试清理空的CUDA上下文\n");
+            return;
+        }
+
+        printf("INFO: 开始清理GPU上下文\n");
+
+        if (ctx->initialized) {
+            if (ctx->use_zero_copy && ctx->h_centers_pinned) {
+                cudaError_t err = cudaFreeHost(ctx->h_centers_pinned);
+                if (err != cudaSuccess) {
+                    printf("WARNING: 释放页锁定内存失败: %s\n", cudaGetErrorString(err));
+                } else {
+                    printf("INFO: 页锁定内存释放成功\n");
+                }
+                ctx->h_centers_pinned = NULL;
+            } else if (ctx->d_centers) {
+                cudaError_t err = cudaFree(ctx->d_centers);
+                if (err != cudaSuccess) {
+                    printf("WARNING: 释放GPU设备内存失败: %s\n", cudaGetErrorString(err));
+                } else {
+                    printf("INFO: GPU设备内存释放成功\n");
+                }
+                ctx->d_centers = NULL;
+            }
+            
+            if (ctx->d_query_vector) {
+                cudaError_t err = cudaFree(ctx->d_query_vector);
+                if (err != cudaSuccess) {
+                    printf("WARNING: 释放查询向量内存失败: %s\n", cudaGetErrorString(err));
+                } else {
+                    printf("INFO: 查询向量内存释放成功\n");
+                }
+                ctx->d_query_vector = NULL;
+            }
+            
+            if (ctx->d_distances) {
+                cudaError_t err = cudaFree(ctx->d_distances);
+                if (err != cudaSuccess) {
+                    printf("WARNING: 释放距离结果内存失败: %s\n", cudaGetErrorString(err));
+                } else {
+                    printf("INFO: 距离结果内存释放成功\n");
+                }
+                ctx->d_distances = NULL;
+            }
+        }
+
+        free(ctx);
+        printf("INFO: GPU上下文清理完成\n");
+    }
+
+    // 上传聚类中心数据到GPU
+    int cuda_upload_centers(CudaCenterSearchContext* ctx, const float* centers_data) {
+        if (!ctx || !ctx->initialized || !centers_data) {
+            printf("ERROR: 无效参数 - ctx: %p, initialized: %d, centers_data: %p\n", 
+                   ctx, ctx ? ctx->initialized : 0, centers_data);
+            return -1;
+        }
+
+        size_t size = ctx->num_centers * ctx->dimensions * sizeof(float);
+        printf("INFO: 开始上传聚类中心数据到GPU (%zu字节, %d个中心, %d维)\n", 
+               size, ctx->num_centers, ctx->dimensions);
+        
+        cudaError_t err = cudaMemcpy(ctx->d_centers, centers_data, size, cudaMemcpyHostToDevice);
+        
+        if (err != cudaSuccess) {
+            printf("ERROR: 聚类中心数据上传失败: %s\n", cudaGetErrorString(err));
+            return -1;
+        }
+
+        printf("INFO: 聚类中心数据上传成功\n");
+        return 0;
+    }
+
+    // 计算聚类中心距离
+    int cuda_compute_center_distances(CudaCenterSearchContext* ctx, 
+                                     const float* query_vector, 
+                                     float* distances) {
+        if (!ctx || !ctx->initialized || !query_vector || !distances) {
+            return -1;
+        }
+
+        // 上传查询向量到GPU
+        size_t query_size = ctx->dimensions * sizeof(float);
+        cudaError_t err = cudaMemcpy(ctx->d_query_vector, query_vector, query_size, cudaMemcpyHostToDevice);
+        if (err != cudaSuccess) {
+            return -1;
+        }
+
+        // 设置CUDA核函数参数
+        int block_size = 256;
+        int grid_size = (ctx->num_centers + block_size - 1) / block_size;
+
+        // 调用L2距离计算核函数
+        compute_l2_distances_kernel<<<grid_size, block_size>>>(
+            ctx->d_centers, 
+            ctx->d_query_vector, 
+            ctx->d_distances, 
+            ctx->num_centers, 
+            ctx->dimensions
+        );
+
+        // 同步设备
+        cudaDeviceSynchronize();
+
+        // 检查错误
+        err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            return -1;
+        }
+
+        // 将结果复制回主机
+        size_t distances_size = ctx->num_centers * sizeof(float);
+        err = cudaMemcpy(distances, ctx->d_distances, distances_size, cudaMemcpyDeviceToHost);
+        if (err != cudaSuccess) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    // 零拷贝方式上传聚类中心数据
+    int cuda_upload_centers_zero_copy(CudaCenterSearchContext* ctx, const float* centers_data) {
+        if (!ctx || !ctx->initialized || !centers_data || !ctx->use_zero_copy) {
+            printf("ERROR: 零拷贝上传参数无效 - ctx: %p, initialized: %d, centers_data: %p, use_zero_copy: %d\n", 
+                   ctx, ctx ? ctx->initialized : 0, centers_data, ctx ? ctx->use_zero_copy : 0);
+            return -1;
+        }
+
+        if (!ctx->h_centers_pinned) {
+            printf("ERROR: 页锁定内存指针为空\n");
+            return -1;
+        }
+
+        size_t size = ctx->num_centers * ctx->dimensions * sizeof(float);
+        printf("INFO: 开始零拷贝上传聚类中心数据 (%zu字节, %d个中心, %d维)\n", 
+               size, ctx->num_centers, ctx->dimensions);
+        
+        // 直接复制到页锁定内存，GPU可以直接访问
+        memcpy(ctx->h_centers_pinned, centers_data, size);
+        
+        printf("INFO: 零拷贝聚类中心数据上传成功\n");
+        return 0;
+    }
+
+    // 设置零拷贝模式
+    int cuda_set_zero_copy_mode(CudaCenterSearchContext* ctx, bool enable) {
+        if (!ctx || !ctx->initialized) {
+            return -1;
+        }
+
+        // 如果模式没有改变，直接返回
+        if (ctx->use_zero_copy == enable) {
+            return 0;
+        }
+
+        // 重新分配内存（简化实现，实际应用中可能需要更复杂的逻辑）
+        ctx->use_zero_copy = enable;
+        
         return 0;
     }
     

--- a/cuda/cuda_wrapper.h
+++ b/cuda/cuda_wrapper.h
@@ -9,6 +9,11 @@ extern int cuda_hello_world(void);
 extern bool cuda_is_available(void);
 
 /*
+* CUDA基本功能测试
+*/
+extern bool cuda_basic_test(void);
+
+/*
 * GPU向量搜索相关接口
 */ 
 extern bool gpu_ivf_search_init(void);
@@ -41,6 +46,31 @@ extern int gpu_ivf_search_cosine_batch(
     int* indices,                  // 输出索引
     int k                          // 返回前k个结果
 );
+
+// GPU聚类中心距离计算相关结构体和函数
+typedef struct {
+    float* d_centers;        // GPU上的聚类中心数据
+    float* d_query_vector;   // GPU上的查询向量
+    float* d_distances;      // GPU上的距离结果
+    float* h_centers_pinned; // 页锁定主机内存（零拷贝用）
+    int num_centers;         // 聚类中心数量
+    int dimensions;          // 向量维度
+    bool initialized;        // 是否已初始化
+    bool use_zero_copy;      // 是否使用零拷贝
+} CudaCenterSearchContext;
+
+// 函数声明
+extern CudaCenterSearchContext* cuda_center_search_init(int num_centers, int dimensions, bool use_zero_copy);
+extern void cuda_center_search_cleanup(CudaCenterSearchContext* ctx);
+extern int cuda_compute_center_distances(CudaCenterSearchContext* ctx, 
+                                        const float* query_vector, 
+                                        float* distances);
+extern int cuda_upload_centers(CudaCenterSearchContext* ctx, 
+                              const float* centers_data);
+extern int cuda_upload_centers_zero_copy(CudaCenterSearchContext* ctx, 
+                                        const float* centers_data);
+extern int cuda_set_zero_copy_mode(CudaCenterSearchContext* ctx, bool enable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ivfflat.c
+++ b/src/ivfflat.c
@@ -51,10 +51,11 @@ IvfflatInit(void)
 	DefineCustomIntVariable("ivfflat.max_probes", "Sets the max number of probes for iterative scans",
 							NULL, &ivfflat_max_probes,
 							IVFFLAT_MAX_LISTS, IVFFLAT_MIN_LISTS, IVFFLAT_MAX_LISTS, PGC_USERSET, 0, NULL, NULL, NULL);
-	// 取消注释来验证cuda代码是否被正确编译
+
 #ifdef USE_CUDA
+	// 验证cuda代码是否被正确编译
 	if(!cuda_is_available()){
-		elog(ERROR, "CUDA is not available!");
+		elog(LOG, "CUDA is not available, GPU features will be disabled!");
 	}
 #endif
 	MarkGUCPrefixReserved("ivfflat");

--- a/src/ivfflat.h
+++ b/src/ivfflat.h
@@ -290,16 +290,22 @@ typedef struct IvfflatScanOpaqueData
 	*/
 #ifdef USE_CUDA
 	bool        use_gpu;           // 是否使用GPU
-	bool        gpu_initialized;   // GPU是否已初始化
-	float*      gpu_query_vector;  // GPU上的查询向量
-	float*      gpu_list_vectors;  // GPU上的列表向量
-	int*        gpu_list_offsets;  // GPU上的列表偏移
-	int*        gpu_list_counts;   // GPU上的列表计数
+	bool        centers_uploaded; // 聚类中心是否已上传到GPU
+	void*       cuda_ctx;          // CUDA上下文
 	float*      gpu_distances;     // GPU上的距离结果
-	int*        gpu_indices;       // GPU上的索引结果
-	size_t      gpu_buffer_size;   // GPU缓冲区大小
-	int         total_vectors;     // 总向量数量
 #endif
+// #ifdef USE_CUDA   
+// 	bool        use_gpu;           // 是否使用GPU
+// 	bool        gpu_initialized;   // GPU是否已初始化
+// 	float*      gpu_query_vector;  // GPU上的查询向量
+// 	float*      gpu_list_vectors;  // GPU上的列表向量
+// 	int*        gpu_list_offsets;  // GPU上的列表偏移
+// 	int*        gpu_list_counts;   // GPU上的列表计数
+// 	float*      gpu_distances;     // GPU上的距离结果
+// 	int*        gpu_indices;       // GPU上的索引结果
+// 	size_t      gpu_buffer_size;   // GPU缓冲区大小
+// 	int         total_vectors;     // 总向量数量
+// #endif
 
 }			IvfflatScanOpaqueData;
 

--- a/src/ivfscan.c
+++ b/src/ivfscan.c
@@ -20,6 +20,12 @@
 #define GetScanList(ptr) pairingheap_container(IvfflatScanList, ph_node, ptr)
 #define GetScanListConst(ptr) pairingheap_const_container(IvfflatScanList, ph_node, ptr)
 
+
+#ifdef USE_CUDA
+static void GetScanLists_GPU(IndexScanDesc scan, Datum value);
+static int UploadCentersToGPU(IndexScanDesc scan);
+#endif
+
 /*
  * Compare list distances
  */
@@ -45,6 +51,14 @@ GetScanLists(IndexScanDesc scan, Datum value)
 	BlockNumber nextblkno = IVFFLAT_HEAD_BLKNO;
 	int			listCount = 0;
 	double		maxDistance = DBL_MAX;
+
+	/* 如果使用GPU加速，先收集所有聚类中心 */
+#ifdef USE_CUDA
+	if (so->use_gpu && so->cuda_ctx) {
+		GetScanLists_GPU(scan, value);
+		return;
+	}
+#endif
 
 	/* Search all list pages */
 	while (BlockNumberIsValid(nextblkno))
@@ -110,6 +124,285 @@ GetScanLists(IndexScanDesc scan, Datum value)
 
 	Assert(pairingheap_is_empty(so->listQueue));
 }
+
+/*
+ * GPU加速版本的聚类中心距离计算
+ */
+#ifdef USE_CUDA
+static void GetScanLists_GPU(IndexScanDesc scan, Datum value)
+{
+	IvfflatScanOpaque so = (IvfflatScanOpaque) scan->opaque;
+	BlockNumber nextblkno = IVFFLAT_HEAD_BLKNO;
+	int			totalLists = 0;
+	int			listCount = 0;
+	int			center_idx = 0;
+	
+	/* 检查聚类中心是否已上传到GPU */
+	if (!so->centers_uploaded) {
+		elog(LOG, "聚类中心数据未上传到GPU，回退到CPU计算");
+		GetScanLists(scan, value);
+		return;
+	}
+	
+	/* 计算总列表数量并收集列表页面信息 */
+	BlockNumber *list_pages = NULL;
+	
+	while (BlockNumberIsValid(nextblkno))
+	{
+		Buffer		cbuf;
+		Page		cpage;
+		OffsetNumber maxoffno;
+
+		cbuf = ReadBuffer(scan->indexRelation, nextblkno);
+		LockBuffer(cbuf, BUFFER_LOCK_SHARE);
+		cpage = BufferGetPage(cbuf);
+		maxoffno = PageGetMaxOffsetNumber(cpage);
+		totalLists += maxoffno;
+		nextblkno = IvfflatPageGetOpaque(cpage)->nextblkno;
+		UnlockReleaseBuffer(cbuf);
+	}
+	
+	/* 分配内存存储列表页面信息 */
+	list_pages = palloc(totalLists * sizeof(BlockNumber));
+	
+	/* 收集列表页面信息 */
+	nextblkno = IVFFLAT_HEAD_BLKNO;
+	
+	while (BlockNumberIsValid(nextblkno))
+	{
+		Buffer		cbuf;
+		Page		cpage;
+		OffsetNumber maxoffno;
+
+		cbuf = ReadBuffer(scan->indexRelation, nextblkno);
+		LockBuffer(cbuf, BUFFER_LOCK_SHARE);
+		cpage = BufferGetPage(cbuf);
+		maxoffno = PageGetMaxOffsetNumber(cpage);
+
+		for (OffsetNumber offno = FirstOffsetNumber; offno <= maxoffno; offno = OffsetNumberNext(offno))
+		{
+			IvfflatList list = (IvfflatList) PageGetItem(cpage, PageGetItemId(cpage, offno));
+			list_pages[center_idx] = list->startPage;
+			center_idx++;
+		}
+
+		nextblkno = IvfflatPageGetOpaque(cpage)->nextblkno;
+		UnlockReleaseBuffer(cbuf);
+	}
+	
+	/* 准备查询向量数据 */
+	float *query_data = (float *) VARDATA(DatumGetPointer(value));
+	
+	/* 使用GPU计算距离 */
+	if (cuda_compute_center_distances((CudaCenterSearchContext*)so->cuda_ctx, query_data, so->gpu_distances) == 0) {
+		/* 使用GPU计算结果进行排序 */
+		double maxDistance = DBL_MAX;
+		
+		for (int i = 0; i < totalLists; i++) {
+			double distance = so->gpu_distances[i];
+			
+			if (listCount < so->maxProbes) {
+				IvfflatScanList *scanlist = &so->lists[listCount];
+				scanlist->startPage = list_pages[i];
+				scanlist->distance = distance;
+				listCount++;
+				
+				/* Add to heap */
+				pairingheap_add(so->listQueue, &scanlist->ph_node);
+				
+				/* Calculate max distance */
+				if (listCount == so->maxProbes)
+					maxDistance = GetScanList(pairingheap_first(so->listQueue))->distance;
+			}
+			else if (distance < maxDistance) {
+				IvfflatScanList *scanlist = GetScanList(pairingheap_remove_first(so->listQueue));
+				
+				/* Reuse */
+				scanlist->startPage = list_pages[i];
+				scanlist->distance = distance;
+				pairingheap_add(so->listQueue, &scanlist->ph_node);
+				
+				/* Update max distance */
+				maxDistance = GetScanList(pairingheap_first(so->listQueue))->distance;
+			}
+		}
+	} else {
+		/* GPU计算失败，回退到CPU计算 */
+		elog(LOG, "GPU distance computation failed, falling back to CPU");
+		GetScanLists(scan, value);
+		pfree(list_pages);
+		return;
+	}
+	
+	/* 输出排序结果 */
+	for (int i = listCount - 1; i >= 0; i--)
+		so->listPages[i] = GetScanList(pairingheap_remove_first(so->listQueue))->startPage;
+
+	Assert(pairingheap_is_empty(so->listQueue));
+	
+	/* 清理临时内存 */
+	pfree(list_pages);
+}
+#endif
+
+/*
+ * 上传聚类中心数据到GPU（在初始化时调用）
+ */
+#ifdef USE_CUDA
+static int UploadCentersToGPU(IndexScanDesc scan)
+{
+	elog(LOG, "UploadCentersToGPU: 函数开始执行");
+	
+	IvfflatScanOpaque so = (IvfflatScanOpaque) scan->opaque;
+	elog(LOG, "UploadCentersToGPU: 获取扫描状态成功, so=%p", so);
+	
+	if (!so) {
+		elog(ERROR, "UploadCentersToGPU: 扫描状态为空");
+		return -1;
+	}
+	
+	elog(LOG, "UploadCentersToGPU: 维度=%d, cuda_ctx=%p, use_gpu=%s", 
+		 so->dimensions, so->cuda_ctx, so->use_gpu ? "是" : "否");
+	
+	BlockNumber nextblkno = IVFFLAT_HEAD_BLKNO;
+	int			totalLists = 0;
+	int			center_idx = 0;
+	int			dimensions = so->dimensions;
+	
+	/* 检查CUDA上下文是否有效 */
+	if (!so->cuda_ctx) {
+		elog(ERROR, "CUDA上下文为空，无法上传聚类中心数据");
+		return -1;
+	}
+	
+	/* 如果已经上传过，直接返回成功 */
+	if (so->centers_uploaded) {
+		elog(LOG, "聚类中心数据已上传，跳过重复上传");
+		return 0;
+	}
+	
+	elog(LOG, "开始收集聚类中心数据 (维度: %d)", dimensions);
+	
+	/* 计算总列表数量 */
+	while (BlockNumberIsValid(nextblkno))
+	{
+		Buffer		cbuf;
+		Page		cpage;
+		OffsetNumber maxoffno;
+
+		cbuf = ReadBuffer(scan->indexRelation, nextblkno);
+		LockBuffer(cbuf, BUFFER_LOCK_SHARE);
+		cpage = BufferGetPage(cbuf);
+		maxoffno = PageGetMaxOffsetNumber(cpage);
+		totalLists += maxoffno;
+		nextblkno = IvfflatPageGetOpaque(cpage)->nextblkno;
+		UnlockReleaseBuffer(cbuf);
+	}
+	
+	if (totalLists <= 0) {
+		elog(ERROR, "没有找到聚类中心数据");
+		return -1;
+	}
+	
+	elog(LOG, "找到 %d 个聚类中心，开始分配内存", totalLists);
+	
+	/* 分配内存存储聚类中心数据 */
+	float *centers_data = palloc(totalLists * dimensions * sizeof(float));
+	if (!centers_data) {
+		elog(ERROR, "无法分配聚类中心数据内存 (%d个中心, %d维)", totalLists, dimensions);
+		return -1;
+	}
+	
+	/* 收集聚类中心数据 */
+	nextblkno = IVFFLAT_HEAD_BLKNO;
+	center_idx = 0;
+	
+	while (BlockNumberIsValid(nextblkno))
+	{
+		Buffer		cbuf;
+		Page		cpage;
+		OffsetNumber maxoffno;
+
+		cbuf = ReadBuffer(scan->indexRelation, nextblkno);
+		LockBuffer(cbuf, BUFFER_LOCK_SHARE);
+		cpage = BufferGetPage(cbuf);
+		maxoffno = PageGetMaxOffsetNumber(cpage);
+
+		for (OffsetNumber offno = FirstOffsetNumber; offno <= maxoffno; offno = OffsetNumberNext(offno))
+		{
+			if (center_idx >= totalLists) {
+				elog(ERROR, "聚类中心索引超出范围: %d >= %d", center_idx, totalLists);
+				UnlockReleaseBuffer(cbuf);
+				pfree(centers_data);
+				return -1;
+			}
+			
+			IvfflatList list = (IvfflatList) PageGetItem(cpage, PageGetItemId(cpage, offno));
+			
+			/* 提取聚类中心向量数据 */
+			Vector *center_vector = &list->center;
+			float *center_data = (float *) VARDATA(center_vector);
+			
+			/* 复制到centers_data数组 */
+			memcpy(&centers_data[center_idx * dimensions], center_data, dimensions * sizeof(float));
+			center_idx++;
+		}
+
+		nextblkno = IvfflatPageGetOpaque(cpage)->nextblkno;
+		UnlockReleaseBuffer(cbuf);
+	}
+	
+	if (center_idx != totalLists) {
+		elog(ERROR, "聚类中心数量不匹配: 预期 %d, 实际 %d", totalLists, center_idx);
+		pfree(centers_data);
+		return -1;
+	}
+	
+	elog(LOG, "聚类中心数据收集完成，开始上传到GPU");
+	
+	/* 上传聚类中心数据到GPU */
+	int upload_result;
+	CudaCenterSearchContext* ctx = (CudaCenterSearchContext*)so->cuda_ctx;
+	
+	/* 添加类型安全检查 */
+	if (!ctx) {
+		elog(ERROR, "CUDA上下文指针为空");
+		pfree(centers_data);
+		return -1;
+	}
+	
+	elog(LOG, "CUDA上下文信息 - 聚类中心数: %d, 维度: %d, 零拷贝: %s, 已初始化: %s", 
+		 ctx->num_centers, ctx->dimensions, 
+		 ctx->use_zero_copy ? "是" : "否",
+		 ctx->initialized ? "是" : "否");
+	
+	if (!ctx->initialized) {
+		elog(ERROR, "CUDA上下文未初始化");
+		pfree(centers_data);
+		return -1;
+	}
+	
+	if (ctx->use_zero_copy) {
+		elog(LOG, "使用零拷贝模式上传数据");
+		upload_result = cuda_upload_centers_zero_copy(ctx, centers_data);
+	} else {
+		elog(LOG, "使用标准模式上传数据");
+		upload_result = cuda_upload_centers(ctx, centers_data);
+	}
+	
+	/* 清理临时内存 */
+	pfree(centers_data);
+	
+	if (upload_result == 0) {
+		so->centers_uploaded = true;
+		elog(LOG, "聚类中心数据已成功上传到GPU (%d个中心)", totalLists);
+	} else {
+		elog(ERROR, "聚类中心数据上传到GPU失败，错误代码: %d", upload_result);
+	}
+	
+	return upload_result;
+}
+#endif
 
 /*
  * Get items
@@ -382,24 +675,74 @@ ivfflatbeginscan(Relation index, int nkeys, int norderbys)
 	so->listIndex = 0;
 	so->lists = palloc(maxProbes * sizeof(IvfflatScanList));
 
-// #ifdef USE_CUDA
-// 	/* 初始化CUDA支持 */
-// 	so->use_cuda = false;
-// 	so->cuda_ctx = NULL;
+#ifdef USE_CUDA
+	/* 初始化GPU支持 */
+	so->use_gpu = false;
+	so->centers_uploaded = false;
+	so->cuda_ctx = NULL;
+	so->gpu_distances = NULL;
 	
-// 	/* 检查CUDA是否可用 */
-// 	if (cuda_is_available()) {
-// 		so->cuda_ctx = cuda_search_init(1000, dimensions); /* 预分配1000个向量 */
-// 		if (so->cuda_ctx) {
-// 			so->use_cuda = true;
-// 			elog(INFO, "CUDA加速已启用");
-// 		}
-// 	}
-// #endif
+	/* 先设置 scan->opaque，这样后续的 GPU 测试才能正常工作 */
+	scan->opaque = so;
+	
+	/* 逐步测试 GPU 功能 */
+	elog(LOG, "开始测试 GPU 功能");
+	
+	/* 测试 CUDA 可用性检查 */
+	if (cuda_is_available()) {
+		elog(LOG, "CUDA 可用性检查通过");
+		
+		/* 测试 CUDA 基本功能 */
+		if (cuda_basic_test()) {
+			elog(LOG, "CUDA 基本功能测试通过");
+			
+			/* 测试 CUDA 上下文初始化 */
+			elog(LOG, "开始测试 CUDA 上下文初始化");
+			so->cuda_ctx = cuda_center_search_init(lists, dimensions, false);
+			if (so->cuda_ctx) {
+				elog(LOG, "CUDA 上下文初始化成功");
+				
+				/* 测试数据上传 */
+				elog(LOG, "开始测试数据上传功能");
+				if (UploadCentersToGPU(scan) == 0) {
+					elog(LOG, "数据上传成功");
+				} else {
+					elog(WARNING, "数据上传失败");
+				}
+				
+				/* 清理 */
+				cuda_center_search_cleanup(so->cuda_ctx);
+				so->cuda_ctx = NULL;
+				elog(LOG, "CUDA 上下文清理完成");
+			} else {
+				elog(WARNING, "CUDA 上下文初始化失败");
+			}
+		} else {
+			elog(WARNING, "CUDA 基本功能测试失败");
+		}
+	} else {
+		elog(LOG, "CUDA 不可用");
+	}
+	
+	/* 启用 GPU 支持 */
+	if (so->cuda_ctx) {
+		so->use_gpu = true;
+		so->gpu_distances = palloc(lists * sizeof(float));
+		if (!so->gpu_distances) {
+			elog(WARNING, "无法分配GPU距离结果内存，将使用CPU计算");
+			so->use_gpu = false;
+			cuda_center_search_cleanup(so->cuda_ctx);
+			so->cuda_ctx = NULL;
+		} else {
+			elog(LOG, "GPU聚类中心搜索已启用（标准模式）");
+		}
+	} else {
+		so->use_gpu = false;
+		so->gpu_distances = NULL;
+	}
+#endif
 
 	MemoryContextSwitchTo(oldCtx);
-
-	scan->opaque = so;
 
 	return scan;
 }
@@ -457,8 +800,11 @@ ivfflatgettuple(IndexScanDesc scan, ScanDirection dir)
 
 		value = GetScanValue(scan);
 		IvfflatBench("GetScanLists", GetScanLists(scan, value));
-		// IvfflatBench("GetScanItems", GetScanItems_GPU(scan, value));
+#ifdef USE_CUDA
+		IvfflatBench("GetScanItems", GetScanItems_GPU(scan, value));
+#else
 		IvfflatBench("GetScanItems", GetScanItems(scan, value));
+#endif
 		so->first = false;
 		so->value = value;
 	}
@@ -468,8 +814,11 @@ ivfflatgettuple(IndexScanDesc scan, ScanDirection dir)
 		if (so->listIndex == so->maxProbes)
 			return false;
 
-		// IvfflatBench("GetScanItems", GetScanItems_GPU(scan, so->value));
+#ifdef USE_CUDA
+		IvfflatBench("GetScanItems", GetScanItems_GPU(scan, so->value));
+#else
 		IvfflatBench("GetScanItems", GetScanItems(scan, so->value));
+#endif
 	}
 
 	heaptid = (ItemPointer) DatumGetPointer(slot_getattr(so->mslot, 2, &isnull));
@@ -491,13 +840,18 @@ ivfflatendscan(IndexScanDesc scan)
 	/* Free any temporary files */
 	tuplesort_end(so->sortstate);
 
-// #ifdef USE_CUDA
-// 	/* 清理CUDA资源 */
-// 	if (so->cuda_ctx) {
-// 		cuda_search_cleanup((CudaSearchContext*)so->cuda_ctx);
-// 		so->cuda_ctx = NULL;
-// 	}
-// #endif
+#ifdef USE_CUDA
+	/* 清理CUDA资源 */
+	if (so->cuda_ctx) {
+		cuda_center_search_cleanup((CudaCenterSearchContext*)so->cuda_ctx);
+		so->cuda_ctx = NULL;
+	}
+	
+	if (so->gpu_distances) {
+		pfree(so->gpu_distances);
+		so->gpu_distances = NULL;
+	}
+#endif
 
 	MemoryContextDelete(so->tmpCtx);
 

--- a/test_gpu/test_gpu_optimization.sql
+++ b/test_gpu/test_gpu_optimization.sql
@@ -1,0 +1,40 @@
+-- 测试GPU优化功能的SQL脚本
+-- 验证聚类中心数据只上传一次的优化效果
+
+-- sudo -u postgres psql -f test_gpu_optimization.sql postgres
+
+-- 创建测试表
+DROP TABLE IF EXISTS test_vectors;
+CREATE TABLE test_vectors (id int, embedding vector(128));
+
+-- 插入测试数据（使用固定模式，确保有匹配结果）
+INSERT INTO test_vectors (id, embedding) 
+SELECT 
+    i,
+    (SELECT array_agg(sin(i + j)) FROM generate_series(1, 128) j)::vector(128)
+FROM generate_series(1, 1000) i;
+
+-- 创建IVFFlat索引
+DROP INDEX IF EXISTS test_vectors_ivfflat_idx;
+CREATE INDEX test_vectors_ivfflat_idx ON test_vectors 
+USING ivfflat (embedding vector_l2_ops) WITH (lists = 50);
+
+-- 生成查询向量（使用与数据相似的模式）
+-- 第一次查询 - 初始化GPU上下文并上传聚类中心
+\timing on
+SELECT id FROM test_vectors 
+ORDER BY embedding <-> (SELECT array_agg(sin(100 + j)) FROM generate_series(1, 128) j)::vector(128) 
+LIMIT 5;
+
+-- 后续查询 - 应该更快，因为聚类中心已在GPU中
+SELECT id FROM test_vectors 
+ORDER BY embedding <-> (SELECT array_agg(sin(200 + j)) FROM generate_series(1, 128) j)::vector(128) 
+LIMIT 5;
+
+SELECT id FROM test_vectors 
+ORDER BY embedding <-> (SELECT array_agg(sin(300 + j)) FROM generate_series(1, 128) j)::vector(128) 
+LIMIT 5;
+\timing off
+
+-- 清理测试数据
+DROP TABLE test_vectors;

--- a/test_gpu/test_optimized_gpu.c
+++ b/test_gpu/test_optimized_gpu.c
@@ -1,0 +1,190 @@
+// gcc -o test_optimized_gpu test_optimized_gpu.c ../cuda/cuda_wrapper.o -I../cuda -L/usr/local/cuda/lib64 -lcudart -lstdc++
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/time.h>
+#include <stdbool.h>
+
+// 模拟PostgreSQL环境
+#include "../cuda/cuda_wrapper.h"
+
+// 测试参数
+#define TEST_DIMENSIONS 128
+#define TEST_CENTERS 1000
+#define TEST_QUERIES 100
+
+// 性能测试结构
+typedef struct {
+    double upload_time;
+    double query_time;
+    int success_count;
+    int total_queries;
+} PerformanceTest;
+
+// 生成随机向量
+void generate_random_vector(float* vector, int dimensions) {
+    for (int i = 0; i < dimensions; i++) {
+        vector[i] = (float)rand() / RAND_MAX * 2.0f - 1.0f;
+    }
+}
+
+// 获取当前时间（微秒）
+double get_time_us() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return tv.tv_sec * 1000000.0 + tv.tv_usec;
+}
+
+// 测试优化后的GPU功能
+int test_optimized_gpu_upload() {
+    printf("=== 测试优化后的GPU聚类中心上传功能 ===\n");
+    
+    // 初始化CUDA上下文
+    CudaCenterSearchContext* ctx = cuda_center_search_init(TEST_CENTERS, TEST_DIMENSIONS, false);
+    if (!ctx) {
+        printf("错误：无法初始化CUDA上下文\n");
+        return -1;
+    }
+    
+    // 生成测试聚类中心数据
+    float* centers_data = (float*)malloc(TEST_CENTERS * TEST_DIMENSIONS * sizeof(float));
+    for (int i = 0; i < TEST_CENTERS; i++) {
+        generate_random_vector(&centers_data[i * TEST_DIMENSIONS], TEST_DIMENSIONS);
+    }
+    
+    // 测试上传性能
+    double start_time = get_time_us();
+    int upload_result = cuda_upload_centers(ctx, centers_data);
+    double end_time = get_time_us();
+    
+    if (upload_result == 0) {
+        printf("✓ 聚类中心数据上传成功\n");
+        printf("✓ 上传时间: %.2f ms\n", (end_time - start_time) / 1000.0);
+    } else {
+        printf("✗ 聚类中心数据上传失败\n");
+        free(centers_data);
+        cuda_center_search_cleanup(ctx);
+        return -1;
+    }
+    
+    // 测试多次查询性能
+    printf("\n=== 测试多次查询性能 ===\n");
+    float* query_vector = (float*)malloc(TEST_DIMENSIONS * sizeof(float));
+    float* distances = (float*)malloc(TEST_CENTERS * sizeof(float));
+    
+    double total_query_time = 0;
+    int successful_queries = 0;
+    
+    for (int q = 0; q < TEST_QUERIES; q++) {
+        generate_random_vector(query_vector, TEST_DIMENSIONS);
+        
+        start_time = get_time_us();
+        int result = cuda_compute_center_distances(ctx, query_vector, distances);
+        end_time = get_time_us();
+        
+        if (result == 0) {
+            total_query_time += (end_time - start_time);
+            successful_queries++;
+        }
+    }
+    
+    printf("✓ 成功查询数: %d/%d\n", successful_queries, TEST_QUERIES);
+    printf("✓ 平均查询时间: %.2f ms\n", (total_query_time / successful_queries) / 1000.0);
+    printf("✓ 总查询时间: %.2f ms\n", total_query_time / 1000.0);
+    
+    // 清理资源
+    free(centers_data);
+    free(query_vector);
+    free(distances);
+    cuda_center_search_cleanup(ctx);
+    
+    return 0;
+}
+
+// 测试零拷贝模式
+int test_zero_copy_mode() {
+    printf("\n=== 测试零拷贝模式 ===\n");
+    
+    CudaCenterSearchContext* ctx = cuda_center_search_init(TEST_CENTERS, TEST_DIMENSIONS, true);
+    if (!ctx) {
+        printf("错误：无法初始化零拷贝CUDA上下文\n");
+        return -1;
+    }
+    
+    // 生成测试数据
+    float* centers_data = (float*)malloc(TEST_CENTERS * TEST_DIMENSIONS * sizeof(float));
+    for (int i = 0; i < TEST_CENTERS; i++) {
+        generate_random_vector(&centers_data[i * TEST_DIMENSIONS], TEST_DIMENSIONS);
+    }
+    
+    // 测试零拷贝上传
+    double start_time = get_time_us();
+    int upload_result = cuda_upload_centers_zero_copy(ctx, centers_data);
+    double end_time = get_time_us();
+    
+    if (upload_result == 0) {
+        printf("✓ 零拷贝模式上传成功\n");
+        printf("✓ 零拷贝上传时间: %.2f ms\n", (end_time - start_time) / 1000.0);
+    } else {
+        printf("✗ 零拷贝模式上传失败\n");
+        free(centers_data);
+        cuda_center_search_cleanup(ctx);
+        return -1;
+    }
+    
+    // 测试查询性能
+    float* query_vector = (float*)malloc(TEST_DIMENSIONS * sizeof(float));
+    float* distances = (float*)malloc(TEST_CENTERS * sizeof(float));
+    
+    generate_random_vector(query_vector, TEST_DIMENSIONS);
+    
+    start_time = get_time_us();
+    int result = cuda_compute_center_distances(ctx, query_vector, distances);
+    end_time = get_time_us();
+    
+    if (result == 0) {
+        printf("✓ 零拷贝模式查询成功\n");
+        printf("✓ 查询时间: %.2f ms\n", (end_time - start_time) / 1000.0);
+    } else {
+        printf("✗ 零拷贝模式查询失败\n");
+    }
+    
+    // 清理资源
+    free(centers_data);
+    free(query_vector);
+    free(distances);
+    cuda_center_search_cleanup(ctx);
+    
+    return 0;
+}
+
+int main() {
+    printf("开始测试优化后的GPU聚类中心上传功能\n");
+    printf("测试参数: 维度=%d, 聚类中心数=%d, 查询数=%d\n\n", 
+           TEST_DIMENSIONS, TEST_CENTERS, TEST_QUERIES);
+    
+    // 检查CUDA可用性
+    if (!cuda_is_available()) {
+        printf("错误：CUDA不可用，无法进行测试\n");
+        return -1;
+    }
+    
+    printf("✓ CUDA环境检查通过\n\n");
+    
+    // 运行测试
+    int result1 = test_optimized_gpu_upload();
+    int result2 = test_zero_copy_mode();
+    
+    printf("\n=== 测试总结 ===\n");
+    if (result1 == 0 && result2 == 0) {
+        printf("✓ 所有测试通过\n");
+        printf("✓ 优化后的GPU功能工作正常\n");
+        printf("✓ 聚类中心数据只需上传一次，后续查询直接使用\n");
+    } else {
+        printf("✗ 部分测试失败\n");
+    }
+    
+    return (result1 == 0 && result2 == 0) ? 0 : -1;
+}


### PR DESCRIPTION
实现上传聚类中心至GPU，包括零拷贝开关支持。针对单个查询向量，不支持批量查询。

主要涉及函数为ivfscan.c中的GetScanLists_GPU(IndexScanDesc scan, Datum value)
**把磁盘上所有聚类中心读到主机内存 → 上传 GPU **

**→ 启动 CUDA kernel ，算完单个查询向量到各个聚类中心的距离 **

cuda_compute_center_distances(so->cuda_ctx, query_data, so->gpu_distances)

  计算的是**l2距离**   其他距离可以在cuda_wrapper.cu里面添加

**→ CPU 端做 top-k 筛选 **

用 最大堆（`pairingheap`）保留最近的 `maxProbes` 个中心